### PR TITLE
Amazon Cloud Player Scrobbler fix

### DIFF
--- a/js/contentscript.js
+++ b/js/contentscript.js
@@ -34,7 +34,8 @@ AmazonParser = function() {
     });
 	
 	this._time = injectScript(function() {
-    	return amznMusic.widgets.player.getCurrentTime();
+		var position = amznMusic.widgets.playerNative.getCurrentTime() + amznMusic.widgets.playerFlash.getCurrentTime();
+		return position;
     });	
 };
 

--- a/js/lastfm_callback.js
+++ b/js/lastfm_callback.js
@@ -1,0 +1,9 @@
+function _url_param(name, url) {
+        return unescape((RegExp(name + '=' +
+            '(.+?)(&|$)').exec(url) || [,null])[1]);
+    }
+
+var background_page = chrome.extension.getBackgroundPage();
+location.href = "http://last.fm/";
+
+background_page.get_lastfm_session(_url_param("token", location.search));

--- a/lastfm_callback.html
+++ b/lastfm_callback.html
@@ -4,14 +4,4 @@
  Copyright (c) 2011 Alexey Savartsov <asavartsov@gmail.com>
  Licensed under the MIT license
 -->
-<script>
-    function _url_param(name, url) {
-        return unescape((RegExp(name + '=' +
-            '(.+?)(&|$)').exec(url) || [,null])[1]);
-    }
-
-    var background_page = chrome.extension.getBackgroundPage();
-    location.href = "http://last.fm/";
-
-    background_page.get_lastfm_session(_url_param("token", location.search));
-</script>
+<script src="js/lastfm_callback.js"></script>

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,6 @@
 {
-    "name": "Amazon Cloud Player scrobbler",
+    "manifest_version": 2,
+	"name": "Amazon Cloud Player scrobbler",
     "version": "1.1.0",
     "description": "Scrobbles songs from Amazon Cloud Player to Last.fm",
     "icons": {
@@ -10,13 +11,13 @@
     },
     "browser_action": {
         "default_icon": "img/main-icon.png",
-        "popup": "popup.html"
+        "default_popup": "popup.html"
     },
     "permissions": [
         "http://ws.audioscrobbler.com/",
         "https://www.amazon.com/"
     ],
-    "background_page" : "background.html",
+    "background" : {"scripts": ["js/md5.js", "js/lastfm.js", "js/jquery-1.7.min.js", "js/background.js"]},
     "content_scripts": [
         {
             "js": ["js/inject.js"],


### PR DESCRIPTION
Updating the Google Chrome Extension manifest to v2.
Fixing retreiving the track position, this was causing track not to be scrobbled.
