### PR TITLE
Support German Amazon Cloud Player scrobbling

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -15,21 +15,22 @@
     },
     "permissions": [
         "http://ws.audioscrobbler.com/",
-        "https://www.amazon.com/"
+        "https://www.amazon.com/",
+        "https://www.amazon.de/"
     ],
     "background" : {"scripts": ["js/md5.js", "js/lastfm.js", "js/jquery-1.7.min.js", "js/background.js"]},
     "content_scripts": [
         {
             "js": ["js/inject.js"],
-            "matches": ["https://www.amazon.com/gp/dmusic/mp3/*"]
+            "matches": ["https://www.amazon.com/gp/dmusic/mp3/*","https://www.amazon.de/gp/dmusic/mp3/*"]
         },
 		{
             "js": ["js/contentscript.js"],
-            "matches": ["https://www.amazon.com/gp/dmusic/mp3/*"]
+            "matches": ["https://www.amazon.com/gp/dmusic/mp3/*", "https://www.amazon.de/gp/dmusic/mp3/*"]
         },
         {
             "js": ["js/jquery-1.7.min.js"],
-            "matches": ["https://www.amazon.com/gp/dmusic/mp3/*"],
+            "matches": ["https://www.amazon.com/gp/dmusic/mp3/*", "https://www.amazon.de/gp/dmusic/mp3/*"],
             "run_at": "document_start"
         }
     ]


### PR DESCRIPTION
Currently just for scrobbling with the easy solution to just add the neccessary URLs.

I will look into how to make a more general purpose solution some time in the future. (e.g. the 'Start Cloud Player' doesn't start the country specific version with this solution)
